### PR TITLE
Adding base class for actors types

### DIFF
--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Private/SogasGasSDK/Actors/SGSActor.cpp
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Private/SogasGasSDK/Actors/SGSActor.cpp
@@ -1,0 +1,11 @@
+#include "SogasGasSDK/Actors/SGSActor.h"
+
+ASGSActor::ASGSActor()
+{
+	AbilitySystemComponent = CreateDefaultSubobject<USGSAbilitySystemComponent>(TEXT("AbilitySystemComponent"));
+}
+
+UAbilitySystemComponent* ASGSActor::GetAbilitySystemComponent() const
+{
+	return AbilitySystemComponent;
+}

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Private/SogasGasSDK/Actors/SGSCharacter.cpp
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Private/SogasGasSDK/Actors/SGSCharacter.cpp
@@ -1,16 +1,16 @@
-#include "SogasGasSDK/Actors/SGSPawn.h"
+#include "SogasGasSDK/Actors/SGSCharacter.h"
 
-ASGSPawn::ASGSPawn()
+ASGSCharacter::ASGSCharacter()
 {
 	AbilitySystemComponent = CreateDefaultSubobject<USGSAbilitySystemComponent>(TEXT("AbilitySystemComponent"));
 }
 
-UAbilitySystemComponent* ASGSPawn::GetAbilitySystemComponent() const
+UAbilitySystemComponent* ASGSCharacter::GetAbilitySystemComponent() const
 {
 	return AbilitySystemComponent;
 }
 
-void ASGSPawn::PossessedBy(AController* InNewController)
+void ASGSCharacter::PossessedBy(AController* InNewController)
 {
 	Super::PossessedBy(InNewController);
 

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Private/SogasGasSDK/Actors/SGSPlayerController.cpp
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Private/SogasGasSDK/Actors/SGSPlayerController.cpp
@@ -1,0 +1,15 @@
+#include "SogasGasSDK/Actors/SGSPlayerController.h"
+#include "SogasGasSDK/Actors/SGSPlayerState.h"
+
+void ASGSPlayerController::OnPossess(APawn* InPawn)
+{
+	Super::OnPossess(InPawn);
+
+	// We should document that the use of ASGSPlayerController should be bound to the use of
+	// ASGSPlayerState if the user wants to automatically init the ability actor info.
+	// Otherwise this logic will need to be implemented manually by the user.
+	if (auto PlayerStateVariable = GetPlayerState<ASGSPlayerState>())
+	{
+		PlayerStateVariable->GetAbilitySystemComponent()->InitAbilityActorInfo(PlayerStateVariable, InPawn);
+	}
+}

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Private/SogasGasSDK/Actors/SGSPlayerState.cpp
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Private/SogasGasSDK/Actors/SGSPlayerState.cpp
@@ -1,0 +1,11 @@
+#include "SogasGasSDK/Actors/SGSPlayerState.h"
+
+ASGSPlayerState::ASGSPlayerState()
+{
+	AbilitySystemComponent = CreateDefaultSubobject<USGSAbilitySystemComponent>(TEXT("AbilitySystemComponent"));
+}
+
+UAbilitySystemComponent* ASGSPlayerState::GetAbilitySystemComponent() const
+{
+	return AbilitySystemComponent;
+}

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSActor.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSActor.h
@@ -1,26 +1,22 @@
 #pragma once
 
 #include "AbilitySystemInterface.h"
-#include "GameFramework/Pawn.h"
+#include "GameFramework/Actor.h"
 #include "SogasGasSDK/Components/SGSAbilitySystemComponent.h"
 
-#include "SGSPawn.generated.h"
+#include "SGSActor.generated.h"
 
 UCLASS()
-class SOGASGASSDK_API ASGSPawn : public APawn, public IAbilitySystemInterface
+class SOGASGASSDK_API ASGSActor : public AActor, public IAbilitySystemInterface
 {
 	GENERATED_BODY()
 
 public:
-	ASGSPawn();
+	ASGSActor();
 
 	//~ Begin IAbilitySystemInterface
 	UAbilitySystemComponent* GetAbilitySystemComponent() const override;
 	//~ End IAbilitySystemInterface
-
-	//~ Begin APawn
-	virtual void PossessedBy(AController* InNewController);
-	//~ End APawn
 
 private:
 	USGSAbilitySystemComponent* AbilitySystemComponent = nullptr;

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSActor.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSActor.h
@@ -20,5 +20,5 @@ public:
 
 private:
 	UPROPERTY()
-	USGSAbilitySystemComponent* AbilitySystemComponent = nullptr;
+	TObjectPtr<USGSAbilitySystemComponent> AbilitySystemComponent = nullptr;
 };

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSActor.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSActor.h
@@ -19,5 +19,6 @@ public:
 	//~ End IAbilitySystemInterface
 
 private:
+	UPROPERTY()
 	USGSAbilitySystemComponent* AbilitySystemComponent = nullptr;
 };

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSCharacter.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSCharacter.h
@@ -26,5 +26,5 @@ public:
 
 private:
 	UPROPERTY()
-	UAbilitySystemComponent* AbilitySystemComponent = nullptr;
+	TObjectPtr<USGSAbilitySystemComponent> AbilitySystemComponent = nullptr;
 };

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSCharacter.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSCharacter.h
@@ -25,5 +25,6 @@ public:
 	//~ End AActor
 
 private:
+	UPROPERTY()
 	UAbilitySystemComponent* AbilitySystemComponent = nullptr;
 };

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSCharacter.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSCharacter.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "AbilitySystemInterface.h"
+#include "GameFramework/Character.h"
+#include "SogasGasSDK/Components/SGSAbilitySystemComponent.h"
+
+#include "SGSCharacter.generated.h"
+
+UCLASS()
+class SOGASGASSDK_API ASGSCharacter : public ACharacter, public IAbilitySystemInterface
+{
+	GENERATED_BODY()
+
+public:
+	ASGSCharacter();
+
+	//~ Begin IAbilitySystemInterface
+	UAbilitySystemComponent* GetAbilitySystemComponent() const override;
+	//~ End IAbilitySystemInterface
+
+	//~ Begin AActor
+	void PossessedBy(AController* InNewController) override;
+	//~ End AActor
+
+private:
+	UAbilitySystemComponent* AbilitySystemComponent = nullptr;
+};

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPawn.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPawn.h
@@ -24,5 +24,5 @@ public:
 
 private:
 	UPROPERTY()
-	USGSAbilitySystemComponent* AbilitySystemComponent = nullptr;
+	TObjectPtr<USGSAbilitySystemComponent> AbilitySystemComponent = nullptr;
 };

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPawn.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPawn.h
@@ -23,5 +23,6 @@ public:
 	//~ End APawn
 
 private:
+	UPROPERTY()
 	USGSAbilitySystemComponent* AbilitySystemComponent = nullptr;
 };

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPlayerController.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPlayerController.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerController.h"
+#include "SGSPlayerController.generated.h"
+
+UCLASS()
+class SOGASGASSDK_API ASGSPlayerController : public APlayerController
+{
+	GENERATED_BODY()
+
+public:
+	void OnPossess(APawn* InPawn) override;
+};

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPlayerState.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPlayerState.h
@@ -21,5 +21,6 @@ public:
     //~ Begin IAbilitySystemInterface
 
 private:
+    UPROPERTY()
     USGSAbilitySystemComponent* AbilitySystemComponent = nullptr;
 };

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPlayerState.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPlayerState.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "AbilitySystemInterface.h"
+#include "GameFramework/PlayerState.h"
+#include "SogasGasSDK/Components/SGSAbilitySystemComponent.h"
+
+#include "SGSPlayerState.generated.h"
+
+UCLASS()
+class SOGASGASSDK_API ASGSPlayerState : public APlayerState, public IAbilitySystemInterface
+{
+	GENERATED_BODY()
+
+public:
+    ASGSPlayerState();
+
+    //~ Begin IAbilitySystemInterface
+    UAbilitySystemComponent* GetAbilitySystemComponent() const override;
+    //~ Begin IAbilitySystemInterface
+
+private:
+    USGSAbilitySystemComponent* AbilitySystemComponent = nullptr;
+};

--- a/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPlayerState.h
+++ b/project/Plugins/SogasGasSDK/Source/SogasGasSDK/Public/SogasGasSDK/Actors/SGSPlayerState.h
@@ -22,5 +22,5 @@ public:
 
 private:
     UPROPERTY()
-    USGSAbilitySystemComponent* AbilitySystemComponent = nullptr;
+    TObjectPtr<USGSAbilitySystemComponent> AbilitySystemComponent = nullptr;
 };


### PR DESCRIPTION
**Issues**
[Resolves Default base class #24](https://github.com/SogasEntertainment/moon-attacks/issues/24)

**Summary**
This pr tries to add the super simplified base classes for actors.
These include:
* AActor
* ACharacter
* APawn
* APlayerController
* APlayerState