### PR TITLE
Renaming player to MoonPlayerPawn

### DIFF
--- a/project/Source/MoonAttacks/Player/MoonPlayerPawn.cpp
+++ b/project/Source/MoonAttacks/Player/MoonPlayerPawn.cpp
@@ -1,5 +1,5 @@
 
-#include "MoonCharacter.h"
+#include "MoonPlayerPawn.h"
 #include "Components/ArrowComponent.h"
 #include "Components/InputComponent.h"
 #include "Components/SphereComponent.h"
@@ -10,7 +10,7 @@
 #include "InputAction.h"
 #include "Kismet/GameplayStatics.h"
 
-AMoonCharacter::AMoonCharacter()
+AMoonPlayerPawn::AMoonPlayerPawn()
 {
 	// Not necessary at the moment.
 	PrimaryActorTick.bCanEverTick = false;
@@ -55,7 +55,7 @@ AMoonCharacter::AMoonCharacter()
 	AutoPossessPlayer = EAutoReceiveInput::Player0;
 }
 
-void AMoonCharacter::BeginPlay()
+void AMoonPlayerPawn::BeginPlay()
 {
 	Super::BeginPlay();
 
@@ -68,7 +68,7 @@ void AMoonCharacter::BeginPlay()
 	}
 }
 
-void AMoonCharacter::Move(const FInputActionValue& InActionValue)
+void AMoonPlayerPawn::Move(const FInputActionValue& InActionValue)
 {
 	const auto value = InActionValue.Get<FVector2D>();
 
@@ -82,13 +82,13 @@ void AMoonCharacter::Move(const FInputActionValue& InActionValue)
 	AddMovementInput(RightVector, value.X);
 }
 
-void AMoonCharacter::Pause(const FInputActionValue& /*InActionValue*/)
+void AMoonPlayerPawn::Pause(const FInputActionValue& /*InActionValue*/)
 {
 	const auto World = GetWorld();
 	UGameplayStatics::SetGamePaused(World, !UGameplayStatics::IsGamePaused(World));
 }
 
-void AMoonCharacter::Shoot(const FInputActionValue& InActionValue)
+void AMoonPlayerPawn::Shoot(const FInputActionValue& InActionValue)
 {
 	const auto value = InActionValue.Get<bool>();
 	if (value)
@@ -97,15 +97,15 @@ void AMoonCharacter::Shoot(const FInputActionValue& InActionValue)
 	}
 }
 
-void AMoonCharacter::SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent)
+void AMoonPlayerPawn::SetupPlayerInputComponent(class UInputComponent* PlayerInputComponent)
 {
 	check(PlayerInputComponent);
 
 	// CastChecked because if input component cast fails, we do not want to continue. So crash the game ...
 	if (auto EnhancedInputComponent = CastChecked<UEnhancedInputComponent>(PlayerInputComponent))
 	{
-		EnhancedInputComponent->BindAction(MoveAction, ETriggerEvent::Triggered, this, &AMoonCharacter::Move);
-		EnhancedInputComponent->BindAction(PauseAction, ETriggerEvent::Triggered, this, &AMoonCharacter::Pause);
-		EnhancedInputComponent->BindAction(ShootAction, ETriggerEvent::Triggered, this, &AMoonCharacter::Shoot);
+		EnhancedInputComponent->BindAction(MoveAction, ETriggerEvent::Triggered, this, &AMoonPlayerPawn::Move);
+		EnhancedInputComponent->BindAction(PauseAction, ETriggerEvent::Triggered, this, &AMoonPlayerPawn::Pause);
+		EnhancedInputComponent->BindAction(ShootAction, ETriggerEvent::Triggered, this, &AMoonPlayerPawn::Shoot);
 	}
 }

--- a/project/Source/MoonAttacks/Player/MoonPlayerPawn.h
+++ b/project/Source/MoonAttacks/Player/MoonPlayerPawn.h
@@ -3,7 +3,7 @@
 #include "InputActionValue.h"
 #include "SogasGasSDK/Actors/SGSPawn.h"
 
-#include "MoonCharacter.generated.h"
+#include "MoonPlayerPawn.generated.h"
 
 class UArrowComponent;
 class UCapsuleComponent;
@@ -14,12 +14,12 @@ class UInputAction;
 class UInputMappingContext;
 
 UCLASS()
-class MOONATTACKS_API AMoonCharacter : public ASGSPawn
+class MOONATTACKS_API AMoonPlayerPawn : public ASGSPawn
 {
 	GENERATED_BODY()
 
 public:
-	AMoonCharacter();
+	AMoonPlayerPawn();
 
 protected:
 	void BeginPlay() override;


### PR DESCRIPTION
**Issues**
[Resolves Rename Moon character #27](https://github.com/SogasEntertainment/moon-attacks/issues/27)

**Summary**
Rename `AMoonCharacter` to `AMoonPlayerPawn` for consistency with the class type.