### PR TITLE
Manage death and first console command

### DIFF
--- a/project/Source/MoonAttacks/GameMode/MoonAttacksGameModeBase.cpp
+++ b/project/Source/MoonAttacks/GameMode/MoonAttacksGameModeBase.cpp
@@ -3,5 +3,5 @@
 
 void AMoonAttacksGameModeBase::PlayerDied()
 {
-    UKismetSystemLibrary::QuitGame(GetWorld(), nullptr, EQuitPreference::Quit, false);
+	UKismetSystemLibrary::QuitGame(GetWorld(), nullptr, EQuitPreference::Quit, false);
 }

--- a/project/Source/MoonAttacks/GameMode/MoonAttacksGameModeBase.cpp
+++ b/project/Source/MoonAttacks/GameMode/MoonAttacksGameModeBase.cpp
@@ -1,3 +1,7 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
-
 #include "MoonAttacksGameModeBase.h"
+#include "Kismet/KismetSystemLibrary.h"
+
+void AMoonAttacksGameModeBase::PlayerDied()
+{
+    UKismetSystemLibrary::QuitGame(GetWorld(), nullptr, EQuitPreference::Quit, false);
+}

--- a/project/Source/MoonAttacks/GameMode/MoonAttacksGameModeBase.h
+++ b/project/Source/MoonAttacks/GameMode/MoonAttacksGameModeBase.h
@@ -10,4 +10,8 @@ UCLASS()
 class MOONATTACKS_API AMoonAttacksGameModeBase : public AGameModeBase
 {
 	GENERATED_BODY()
+
+public:
+
+	void PlayerDied();
 };

--- a/project/Source/MoonAttacks/GameMode/MoonAttacksGameModeBase.h
+++ b/project/Source/MoonAttacks/GameMode/MoonAttacksGameModeBase.h
@@ -12,6 +12,5 @@ class MOONATTACKS_API AMoonAttacksGameModeBase : public AGameModeBase
 	GENERATED_BODY()
 
 public:
-
 	void PlayerDied();
 };

--- a/project/Source/MoonAttacks/Player/MoonPlayerController.cpp
+++ b/project/Source/MoonAttacks/Player/MoonPlayerController.cpp
@@ -1,1 +1,11 @@
 #include "MoonPlayerController.h"
+#include "MoonAttacks/Abilities/AttributeSets/MoonBaseAttributeSet.h"
+#include "MoonPlayerState.h"
+
+void AMoonPlayerController::Kill()
+{
+	if (auto PlayerStateVariable = GetPlayerState<AMoonPlayerState>())
+	{
+		PlayerStateVariable->GetAttributeSet<UMoonBaseAttributeSet>(UMoonBaseAttributeSet::StaticClass())->SetHealth(0.0f);
+	}
+}

--- a/project/Source/MoonAttacks/Player/MoonPlayerController.h
+++ b/project/Source/MoonAttacks/Player/MoonPlayerController.h
@@ -8,4 +8,8 @@ UCLASS()
 class MOONATTACKS_API AMoonPlayerController : public ASGSPlayerController
 {
 	GENERATED_BODY()
+
+public:
+	UFUNCTION(Exec)
+	void Kill();
 };

--- a/project/Source/MoonAttacks/Player/MoonPlayerState.cpp
+++ b/project/Source/MoonAttacks/Player/MoonPlayerState.cpp
@@ -1,8 +1,21 @@
 #include "MoonPlayerState.h"
 #include "MoonAttacks/Abilities/AttributeSets/MoonBaseAttributeSet.h"
+#include "MoonAttacks/GameMode/MoonAttacksGameModeBase.h"
+#include "MoonCharacter.h"
 
 AMoonPlayerState::AMoonPlayerState()
 {
+}
+
+void AMoonPlayerState::BeginPlay()
+{
+	if (auto ASC = GetAbilitySystemComponent())
+	{
+		if (auto AttributeSet = GetAttributeSet<UMoonBaseAttributeSet>(UMoonBaseAttributeSet::StaticClass()))
+		{
+			OnHealthChangedDelegateHandle = ASC->GetGameplayAttributeValueChangeDelegate(AttributeSet->GetHealthAttribute()).AddUObject(this, &AMoonPlayerState::OnHealthChanged);
+		}
+	}
 }
 
 bool AMoonPlayerState::IsAlive() const
@@ -48,4 +61,19 @@ float AMoonPlayerState::GetMaxSpeed() const
 	}
 
 	return 0.0f;
+}
+
+void AMoonPlayerState::OnHealthChanged(const FOnAttributeChangeData& InData)
+{
+	auto Player = Cast<AMoonCharacter>(GetPawn());
+
+	if (IsValid(Player) && !IsAlive())
+	{
+		GetAbilitySystemComponent()->CancelAllAbilities();
+
+		if (auto MoonGameMode = Cast<AMoonAttacksGameModeBase>(GetWorld()->GetAuthGameMode()))
+		{
+			MoonGameMode->PlayerDied();
+		}
+	}
 }

--- a/project/Source/MoonAttacks/Player/MoonPlayerState.h
+++ b/project/Source/MoonAttacks/Player/MoonPlayerState.h
@@ -14,12 +14,14 @@ class MOONATTACKS_API AMoonPlayerState : public ASGSPlayerState
 public:
 	AMoonPlayerState();
 
+	void BeginPlay() override;
+
 	template <class T>
-	const T* GetAttributeSet(TSubclassOf<T> InAttributeSetClass) const
+	T* GetAttributeSet(TSubclassOf<T> InAttributeSetClass) const
 	{
 		if (auto AttributeSet = GetAbilitySystemComponent()->GetAttributeSet(InAttributeSetClass))
 		{
-			return Cast<T>(AttributeSet);
+			return const_cast<T*>(Cast<T>(AttributeSet));
 		}
 
 		return nullptr;
@@ -39,4 +41,9 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "MoonAttacks|Attributes")
 	float GetMaxSpeed() const;
+
+protected:
+	FDelegateHandle OnHealthChangedDelegateHandle;
+
+	virtual void OnHealthChanged(const FOnAttributeChangeData& InData);
 };


### PR DESCRIPTION
**Issues**
Resolves [Add death logic #34 ](#34 )

**Summary**
This pull requests adds a callback for when the health attribute changes. This callback at the moment only checks if the player is valid and alive. If it is not alive, calls the `GameMode` function `PlayerDied` to handle this event.
At the moment the game is just closed as we do not have any menu to return to.

A generic function to recover an `AttributeSet` has been added in `PlayerState`.